### PR TITLE
fix: pin GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -11,14 +11,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ github.head_ref }}
 
       - name: Fix PHP code style issues
-        uses: aglipanci/laravel-pint-action@2.6
+        uses: aglipanci/laravel-pint-action@36de00d5f5a8a4e12d443e01671daa12a18f4c79 # 2.6
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7
         with:
           commit_message: Fix styling

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -11,16 +11,16 @@ jobs:
     name: phpstan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.2'
           coverage: none
 
       - name: Install composer dependencies
-        uses: ramsey/composer-install@v4
+        uses: ramsey/composer-install@26d8a556604053a9612623447203a691f406fbe6 # v4
 
       - name: Run PHPStan
         run: ./vendor/bin/phpstan --error-format=github

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
@@ -60,10 +60,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
@@ -99,10 +99,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php }}
           extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo


### PR DESCRIPTION
## Summary
Pins third-party GitHub Actions to full commit SHA instead of tag/branch refs.

## Why
A tag can be re-pointed by a compromised maintainer (tj-actions/changed-files incident, 2025-03) to exfiltrate CI secrets. Pinning to SHA guarantees the code that ran yesterday runs again today.

## Pinned
- actions/checkout@v6 -> d23441a48e516b6c34aea4fa41551a30e30af803 (fix-php-code-style-issues.yml)
- aglipanci/laravel-pint-action@2.6 -> 36de00d5f5a8a4e12d443e01671daa12a18f4c79 (fix-php-code-style-issues.yml)
- stefanzweifel/git-auto-commit-action@v7 -> 4a55954c782fc1ea30b9056cd3e7a2b40ca8887d (fix-php-code-style-issues.yml)
- actions/checkout@v6 -> d23441a48e516b6c34aea4fa41551a30e30af803 (phpstan.yml)
- shivammathur/setup-php@v2 -> f3e473d116dcccaddc5834248c87452386958240 (phpstan.yml)
- ramsey/composer-install@v4 -> 26d8a556604053a9612623447203a691f406fbe6 (phpstan.yml)
- actions/checkout@v6 -> d23441a48e516b6c34aea4fa41551a30e30af803 (run-tests.yml)
- shivammathur/setup-php@v2 -> f3e473d116dcccaddc5834248c87452386958240 (run-tests.yml)
- actions/checkout@v6 -> d23441a48e516b6c34aea4fa41551a30e30af803 (run-tests.yml)
- shivammathur/setup-php@v2 -> f3e473d116dcccaddc5834248c87452386958240 (run-tests.yml)
- actions/checkout@v6 -> d23441a48e516b6c34aea4fa41551a30e30af803 (run-tests.yml)
- shivammathur/setup-php@v2 -> f3e473d116dcccaddc5834248c87452386958240 (run-tests.yml)
